### PR TITLE
bugfix: ensure the user has requested the DbSecret to be renewed

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ kind: DbSecret
 metadata:
   name: cassandra
 spec:
+  renew: true # this is the default, otherwise a new credential will be generated every time
   vault:
     role: readonly
     mount: cass000

--- a/controllers/dbsecret_controller.go
+++ b/controllers/dbsecret_controller.go
@@ -173,7 +173,7 @@ func (r *DbSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if !shouldUpdate {
 			return ctrl.Result{RequeueAfter: r.ReconciliationPeriod}, nil
 		}
-		if canRenew {
+		if canRenew && dbSecret.Spec.Renew {
 			err = r.renewLease(&dbSecret, currentSecret)
 			if err != nil {
 				r.Log.Error(err, "Lease could not be extended", "name", dbSecret.Name, "namespace", dbSecret.Namespace)


### PR DESCRIPTION
The default is for the secret to be renewed but the end-user may decide to generate a brand new secret every time