### PR TITLE
Refactoring to add templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,9 @@ spec:
   vault:
     role: readonly
     mount: cass000
-  secret: # optional: vault returns the values as `username` and `password` but you may need different variable names
-    username: "CASSANDRA_USERNAME"
-    password: "CASSANDRA_PASSWORD"
-    CASSANDRA_HOSTS: 127.0.0.1 # anything other than username and password are literals you can define
+  template: # optional: change the secret format
+    CASSANDRA_USERNAME: "{{ .username }}"
+    CASSANDRA_PASSWORD: "{{ .password }}"
   rollout: # optional: run a `rollout` to make the pods use new credentials
     - kind: Deployment
       name: cassandra-client

--- a/README.md
+++ b/README.md
@@ -121,6 +121,35 @@ The default encoding is `text` but you can change it to `base64` per secret refe
 You may also use GoLang templates to format a secret. You can inject as variables any of the keys referenced in the `data` section to format, for example, a configuration file.
 The [sprig](https://github.com/Masterminds/sprig/blob/master/docs/index.md) functions are supported.
 
+## Vault database credentials
+
+---
+> **_NOTE:_**  Vault >= 1.10 is required for this feature to work
+---
+
+A great feature in HashiCorp Vault is the generate [database credentials](https://developer.hashicorp.com/vault/docs/secrets/databases) dynamically.
+The missing part is you need these credentials in Kubernertes where your applications are. This is why we have added a new resource definition to do just that:
+
+```yaml
+apiVersion: digitalis.io/v1beta1
+kind: DbSecret
+metadata:
+  name: cassandra
+spec:
+  renew: true # this is the default, otherwise a new credential will be generated every time
+  vault:
+    role: readonly
+    mount: cass000
+  template: # optional: change the secret format
+    CASSANDRA_USERNAME: "{{ .username }}"
+    CASSANDRA_PASSWORD: "{{ .password }}"
+  rollout: # optional: run a `rollout` to make the pods use new credentials
+    - kind: Deployment
+      name: cassandra-client
+    - kind: StatefulSet
+      name: cassandra-client-other
+```
+
 ## Advance config: password rotation
 
 If you're running a database you may want to keep the secrets in sync between your secrets store, Kubernetes and the database. This can be handy for password rotation to ensure the clients don't use the same password all the time. Please be aware your client *must* suppport re-reading the secret and reconnecting whenever it is updated.
@@ -191,35 +220,6 @@ spec:
       hosts:
         - my-elastic                    # this would be converted to http://my-elastic:9200
         - https://my-other-elastic:9200 # provide full URL instead
-```
-
-## Vault database credentials
-
----
-> **_NOTE:_**  Vault >= 1.10 is required for this feature to work
----
-
-A great feature in HashiCorp Vault is the generate [database credentials](https://developer.hashicorp.com/vault/docs/secrets/databases) dynamically.
-The missing part is you need these credentials in Kubernertes where your applications are. This is why we have added a new resource definition to do just that:
-
-```yaml
-apiVersion: digitalis.io/v1beta1
-kind: DbSecret
-metadata:
-  name: cassandra
-spec:
-  renew: true # this is the default, otherwise a new credential will be generated every time
-  vault:
-    role: readonly
-    mount: cass000
-  template: # optional: change the secret format
-    CASSANDRA_USERNAME: "{{ .username }}"
-    CASSANDRA_PASSWORD: "{{ .password }}"
-  rollout: # optional: run a `rollout` to make the pods use new credentials
-    - kind: Deployment
-      name: cassandra-client
-    - kind: StatefulSet
-      name: cassandra-client-other
 ```
 
 ## Options

--- a/apis/digitalis.io/v1beta1/dbsecret_types.go
+++ b/apis/digitalis.io/v1beta1/dbsecret_types.go
@@ -28,7 +28,7 @@ type DbSecretSpec struct {
 	// Name can override the secret name, defaults to manifests.name
 	SecretName string            `json:"secretName,omitempty"`
 	Vault      DbVaultConfig     `json:"vault"`
-	Secret     map[string]string `json:"secret,omitempty"`
+	Template   map[string]string `json:"template,omitempty"`
 	Renew      bool              `json:"renew,omitempty"`
 	Rollout    []DbRolloutTarget `json:"rollout,omitempty"`
 }

--- a/apis/digitalis.io/v1beta1/zz_generated.deepcopy.go
+++ b/apis/digitalis.io/v1beta1/zz_generated.deepcopy.go
@@ -118,8 +118,8 @@ func (in *DbSecretRollout) DeepCopy() *DbSecretRollout {
 func (in *DbSecretSpec) DeepCopyInto(out *DbSecretSpec) {
 	*out = *in
 	out.Vault = in.Vault
-	if in.Secret != nil {
-		in, out := &in.Secret, &out.Secret
+	if in.Template != nil {
+		in, out := &in.Template, &out.Template
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/charts/vals-operator/Chart.yaml
+++ b/charts/vals-operator/Chart.yaml
@@ -7,9 +7,9 @@ kubeVersion: ">= 1.19.0-0"
 type: application
 
 # Chart version
-version: 0.6.4
+version: 0.7.0
 # Latest container tag
-appVersion: "0.6.4"
+appVersion: "0.7.0"
 
 maintainers:
 - email: info@digitalis.io

--- a/charts/vals-operator/crds/dbsecrets.yaml
+++ b/charts/vals-operator/crds/dbsecrets.yaml
@@ -53,13 +53,13 @@ spec:
                   - name
                   type: object
                 type: array
-              secret:
-                additionalProperties:
-                  type: string
-                type: object
               secretName:
                 description: Name can override the secret name, defaults to manifests.name
                 type: string
+              template:
+                additionalProperties:
+                  type: string
+                type: object
               vault:
                 properties:
                   mount:

--- a/config/crd/bases/digitalis.io_dbsecrets.yaml
+++ b/config/crd/bases/digitalis.io_dbsecrets.yaml
@@ -51,13 +51,13 @@ spec:
                   - name
                   type: object
                 type: array
-              secret:
-                additionalProperties:
-                  type: string
-                type: object
               secretName:
                 description: Name can override the secret name, defaults to manifests.name
                 type: string
+              template:
+                additionalProperties:
+                  type: string
+                type: object
               vault:
                 properties:
                   mount:

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -9,6 +9,7 @@ const (
 	lastUpdatedAnnotation      = "vals-operator.digitalis.io/last-updated"
 	recordingEnabledAnnotation = "vals-operator.digitalis.io/record"
 	forceCreateAnnotation      = "vals-operator.digitalis.io/force"
+	templateHash               = "vals-operator.digitalis.io/hash"
 	managedByLabel             = "app.kubernetes.io/managed-by"
 	k8sSecretPrefix            = "ref+k8s://"
 )

--- a/controllers/dbsecret_controller.go
+++ b/controllers/dbsecret_controller.go
@@ -162,6 +162,15 @@ func (r *DbSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			canRenew = false
 		}
 
+		/* If the new secret doesn't have a template anymore, make sure it's deleted from the secret */
+		if len(dbSecret.Spec.Template) == 0 {
+			for k, _ := range currentSecret.Data {
+				if k != "username" && k != "password" {
+					delete(currentSecret.Data, k)
+				}
+			}
+		}
+
 		newHash := utils.CreateFakeHash(dbSecret.Spec.Template)
 		if newHash != "" && currentSecret.Annotations[templateHash] != "" {
 			if newHash != currentSecret.Annotations[templateHash] {

--- a/controllers/dbsecret_controller.go
+++ b/controllers/dbsecret_controller.go
@@ -20,10 +20,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"html/template"
 	"strconv"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	sprig "github.com/Masterminds/sprig/v3"

--- a/controllers/dbsecret_controller.go
+++ b/controllers/dbsecret_controller.go
@@ -313,7 +313,6 @@ func (r *DbSecretReconciler) upsertSecret(sDef *digitalisiov1beta1.DbSecret, cre
 	dataStr["password"] = creds.Password
 	data := r.renderTemplate(sDef, dataStr)
 
-	/* FIXME: what is username is in the template but not the password */
 	if len(data) < 1 {
 		secret.StringData = dataStr
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,9 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/a8m/envsubst v1.3.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.14.1
 )
 
+require github.com/Masterminds/sprig v2.22.0+incompatible
+
 require (
 	cloud.google.com/go v0.107.0 // indirect
 	cloud.google.com/go/compute v1.14.0 // indirect
@@ -53,7 +55,6 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
-	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/a8m/envsubst v1.3.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,12 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
+github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -67,12 +67,6 @@ func ByteMapsMatch(m1, m2 map[string][]byte) bool {
 	return true
 }
 
-// SecretStringByteMatch returns true if map[string]string and map[string][]byte have the same contents
-func SecretStringByteMatch(s map[string]string, b map[string][]byte) bool {
-
-	return true
-}
-
 func MergeMap(dst map[string]string, src map[string]string) {
 	for k, v := range src {
 		dst[k] = v
@@ -132,16 +126,6 @@ func SecretHashString(m map[string]string) string {
 	var str string
 	for _, k := range SortedKeysMapString(m) {
 		str = fmt.Sprintf("%s%s%s", str, k, m[k])
-	}
-	hasher := md5.New()
-	hasher.Write([]byte(str))
-	return hex.EncodeToString(hasher.Sum(nil))
-}
-
-func SecretHashBytes(m map[string][]byte) string {
-	var str string
-	for k, v := range m {
-		str = fmt.Sprintf("%s%s%s", str, k, v)
 	}
 	hasher := md5.New()
 	hasher.Write([]byte(str))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -151,6 +151,7 @@ func CreateFakeHash(m map[string]string) string {
 
 		data[k] = string(b.Bytes())
 	}
+
 	return SecretHashString(data)
 }
 


### PR DESCRIPTION
Refactored to use templates instead of the weird format we had before. This make a lot more sense. 
```yaml
apiVersion: digitalis.io/v1beta1
kind: DbSecret
metadata:
  name: db-secret
spec:
  vault:
    mount: cass000
    role: reaonly
  template:
    CASSANDRA_USERNAME: "{{ .username }}"
    CASSANDRA_PASSWORD: "{{ .password }}"
```