### PR TITLE
Fix default container location

### DIFF
--- a/charts/vals-operator/Chart.yaml
+++ b/charts/vals-operator/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 version: 0.7.2
 
 # Latest container tag
-appVersion: "0.7.2"
+appVersion: "v0.7.2"
 
 maintainers:
 - email: info@digitalis.io


### PR DESCRIPTION
The default value was missing a `v` character in the container image tag. The correct location is `ghcr.io/digitalis-io/vals-operator:v0.7.2`.

Without this change, a default `helm install ...` ends up in the `ImagePullBackOff` state.