### PR TITLE
Permit deployment/sts rollout even if there are no running replicas

### DIFF
--- a/charts/vals-operator/Chart.yaml
+++ b/charts/vals-operator/Chart.yaml
@@ -16,10 +16,10 @@ kubeVersion: ">= 1.19.0-0"
 type: application
 
 # Chart version
-version: 0.7.5
+version: 0.7.6-beta1
 
 # Latest container tag
-appVersion: v0.7.5
+appVersion: v0.7.6-beta1
 
 maintainers:
 - email: info@digitalis.io

--- a/controllers/dbsecret_controller.go
+++ b/controllers/dbsecret_controller.go
@@ -488,12 +488,10 @@ func (r *DbSecretReconciler) rollout(sDef *digitalisiov1beta1.DbSecret, rolloutT
 			return err
 		}
 
-		if object.Status.ReadyReplicas > 0 {
-			object.Spec.Template.Annotations[restartedAnnotation] = time.Now().UTC().Format(timeLayout)
-			err = r.Update(r.Ctx, &object)
-			if err != nil {
-				return err
-			}
+		object.Spec.Template.Annotations[restartedAnnotation] = time.Now().UTC().Format(timeLayout)
+		err = r.Update(r.Ctx, &object)
+		if err != nil {
+			return err
 		}
 	} else if strings.ToLower(rolloutTarget.Kind) == "statefulset" {
 		var object v1.StatefulSet
@@ -506,12 +504,10 @@ func (r *DbSecretReconciler) rollout(sDef *digitalisiov1beta1.DbSecret, rolloutT
 			return err
 		}
 
-		if object.Status.ReadyReplicas > 0 {
-			object.Spec.Template.Annotations[restartedAnnotation] = time.Now().UTC().Format(timeLayout)
-			err = r.Update(r.Ctx, &object)
-			if err != nil {
-				return err
-			}
+		object.Spec.Template.Annotations[restartedAnnotation] = time.Now().UTC().Format(timeLayout)
+		err = r.Update(r.Ctx, &object)
+		if err != nil {
+			return err
 		}
 	} else {
 		return fmt.Errorf("%s kind is not supported", rolloutTarget.Kind)


### PR DESCRIPTION
In my scenario, I have a stateful set with a single pod that's not running because the health check is failing. I want to update the db credentials but vals-operator won't trigger a rolling restart if there are no running pods.