### PR TITLE
feat(ci): sign release artifacts with cosign and publish SBOMs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,15 @@ jobs:
       - name: Log into ghcr.io Helm registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
 
+      # cosign reads Docker config (~/.docker/config.json) to push signature
+      # blobs; helm registry login does not populate this. Both logins needed.
+      - name: Log into GHCR for cosign
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Package Helm chart
         run: helm package charts/vals-operator --destination /tmp/helm-packages
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      id-token: write       # cosign keyless signing + SBOM attestation via Fulcio
+      contents: write       # anchore/sbom-action uploads SBOM as Release asset
     steps:
       - name: Check out the repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -45,6 +47,7 @@ jobs:
           password: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           platforms: linux/amd64,linux/arm/v6,linux/arm64
@@ -60,6 +63,48 @@ jobs:
           labels: |
             LABEL org.opencontainers.image.source="https://github.com/${{ env.REPO_OWNER }}/vals-operator"
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+
+      # Sign the image by digest (immutable) rather than tag (mutable). Signature
+      # is stored alongside the image in GHCR and verifiable with the Fulcio
+      # certificate identity emitted by this workflow run. See README "Verifying
+      # Signatures" for the verify command consumers should use.
+      - name: Sign container image with cosign (keyless)
+        env:
+          IMAGE: ghcr.io/${{ env.REPO_OWNER }}/vals-operator@${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}"
+
+      # Generate SBOM by scanning the image from the registry by digest, so the
+      # SBOM reflects exactly the bytes pushed (not the build context).
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@fc46e51fd3cb168ffb36c6d1915723c47db58abb # v0.17.7
+        with:
+          image: ghcr.io/${{ env.REPO_OWNER }}/vals-operator@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          artifact-name: vals-operator-${{ env.TAG }}-sbom.spdx.json
+          output-file: /tmp/vals-operator-sbom.spdx.json
+          upload-release-assets: true
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@fc46e51fd3cb168ffb36c6d1915723c47db58abb # v0.17.7
+        with:
+          image: ghcr.io/${{ env.REPO_OWNER }}/vals-operator@${{ steps.build.outputs.digest }}
+          format: cyclonedx-json
+          artifact-name: vals-operator-${{ env.TAG }}-sbom.cdx.json
+          upload-release-assets: true
+
+      # Record the SPDX SBOM as a cosign attestation on the image digest. This
+      # attestation is retrievable with `cosign verify-attestation --type spdxjson`.
+      - name: Attest SBOM to image with cosign
+        env:
+          IMAGE: ghcr.io/${{ env.REPO_OWNER }}/vals-operator@${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest --yes \
+            --predicate /tmp/vals-operator-sbom.spdx.json \
+            --type spdxjson \
+            "${IMAGE}"
+
   # Publish the Helm chart as an OCI artifact to ghcr.io.
   # The traditional Helm repo at https://digitalis-io.github.io/helm-charts
   # remains the primary distribution channel and is managed in a separate repo.
@@ -71,6 +116,7 @@ jobs:
     needs: [release]
     permissions:
       packages: write
+      id-token: write       # cosign keyless signing of the OCI chart artifact
     steps:
       - name: Check out the repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -101,5 +147,25 @@ jobs:
       - name: Package Helm chart
         run: helm package charts/vals-operator --destination /tmp/helm-packages
 
+      # Capture the OCI digest emitted by `helm push` so cosign can sign by digest.
+      # `helm push` writes "Digest: sha256:..." on stdout for OCI pushes.
       - name: Push Helm chart to OCI registry
-        run: helm push "/tmp/helm-packages/vals-operator-${CHART_VERSION}.tgz" oci://ghcr.io/digitalis-io/helm-charts
+        id: helm_push
+        run: |
+          set -euo pipefail
+          helm push "/tmp/helm-packages/vals-operator-${CHART_VERSION}.tgz" \
+            oci://ghcr.io/digitalis-io/helm-charts 2>&1 | tee /tmp/helm-push.log
+          DIGEST="$(grep -E '^Digest: ' /tmp/helm-push.log | awk '{print $2}')"
+          if [ -z "${DIGEST}" ]; then
+            echo "Failed to extract chart digest from helm push output" >&2
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+
+      - name: Sign Helm OCI chart with cosign (keyless)
+        env:
+          CHART_REF: ghcr.io/digitalis-io/helm-charts/vals-operator@${{ steps.helm_push.outputs.digest }}
+        run: cosign sign --yes "${CHART_REF}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Vals-operator uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - New `-allowed-namespaces-for-sync` flag to allowlist specific namespaces for cross-namespace `ref+k8s://` access. References targeting namespaces outside the list are rejected. An empty value (the default) permits all namespaces. `-disable-namespace-sync` takes precedence over this flag when both are set. ([#91](https://github.com/digitalis-io/vals-operator/issues/91))
 - Helm chart is now published as an OCI artifact to `oci://ghcr.io/digitalis-io/helm-charts/vals-operator` on every release, enabling installation without `helm repo add` on Helm 3.8+. ([#95](https://github.com/digitalis-io/vals-operator/issues/95))
 
+### Security
+
+- Container images and the Helm OCI chart are now signed on every release using cosign keyless signing via GitHub Actions OIDC. Consumers can verify signatures without trusting any long-lived key. See README for `cosign verify` commands. ([#98](https://github.com/digitalis-io/vals-operator/issues/98))
+- SPDX 2.3 JSON and CycloneDX 1.5 JSON SBOMs are now generated for every released container image and attached as GitHub Release assets. The SPDX SBOM is additionally recorded as a cosign attestation on the image digest, verifiable with `cosign verify-attestation --type spdxjson`. See README for download and verification commands. ([#99](https://github.com/digitalis-io/vals-operator/issues/99))
+
 ### Changed
 
 - Updated all Go module dependencies to latest stable versions; fixed `ENVTEST_K8S_VERSION` and bumped `CONTROLLER_TOOLS_VERSION`. ([#94](https://github.com/digitalis-io/vals-operator/issues/94))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.25 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.26 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/README.md
+++ b/README.md
@@ -125,6 +125,63 @@ helm upgrade vals-operator oci://ghcr.io/digitalis-io/helm-charts/vals-operator 
 
 > **Note:** The traditional Helm repository at `https://digitalis-io.github.io/helm-charts` remains available during the transition. Consumers on Helm 3.7 or earlier MUST use the `helm repo add` method above.
 
+## Verifying Signatures
+
+Container images and the Helm OCI chart are signed on every release using
+[cosign](https://github.com/sigstore/cosign) keyless signing via GitHub Actions
+OIDC. No long-lived signing key is used — verification trusts only the Sigstore
+public infrastructure and the workflow identity that produced the artifact.
+
+Install cosign with `brew install cosign` or grab a binary from the
+[Sigstore releases page](https://github.com/sigstore/cosign/releases).
+
+> **Important:** Always verify by an immutable reference — the version tag
+> (`vX.Y.Z`) or, preferably, the image digest (`@sha256:...`). The mutable
+> `:latest` tag is not a stable signing target.
+
+Verify the container image (substitute the release tag):
+
+```sh
+cosign verify ghcr.io/digitalis-io/vals-operator:<TAG> \
+  --certificate-identity-regexp "^https://github\.com/digitalis-io/vals-operator/\.github/workflows/release\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  | jq .
+```
+
+Verify the Helm OCI chart (substitute the chart version, no leading `v`):
+
+```sh
+cosign verify ghcr.io/digitalis-io/helm-charts/vals-operator:<CHART_VERSION> \
+  --certificate-identity-regexp "^https://github\.com/digitalis-io/vals-operator/\.github/workflows/release\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  | jq .
+```
+
+## Software Bill of Materials
+
+Every released container image ships with an SPDX 2.3 JSON and a CycloneDX 1.5
+JSON SBOM. Both are attached as assets to the corresponding GitHub Release, and
+the SPDX SBOM is additionally recorded as a cosign attestation on the image
+digest.
+
+Download from the GitHub Release:
+
+```
+https://github.com/digitalis-io/vals-operator/releases/download/<TAG>/vals-operator-<TAG>-sbom.spdx.json
+https://github.com/digitalis-io/vals-operator/releases/download/<TAG>/vals-operator-<TAG>-sbom.cdx.json
+```
+
+Verify the SBOM attestation against the image digest:
+
+```sh
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp "^https://github\.com/digitalis-io/vals-operator/\.github/workflows/release\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/digitalis-io/vals-operator@<DIGEST> \
+  | jq '.payload | @base64d | fromjson'
+```
+
 ## Secrets Backend Configuration
 
 vals-operator now supports **both HashiCorp Vault and OpenBao** as secrets backends. The operator automatically detects which backend to use based on the environment variables you provide.


### PR DESCRIPTION
## Summary

- Sign container image by digest with cosign keyless (Fulcio/Rekor) via GitHub Actions OIDC.
- Sign Helm OCI chart by digest with cosign keyless.
- Generate SPDX 2.3 JSON + CycloneDX 1.5 JSON SBOMs from the registry image by digest, attach to GitHub Release.
- Record SPDX SBOM as a cosign attestation on the image digest (`--type spdxjson`).
- README: new `Verifying Signatures` and `Software Bill of Materials` sections with verify commands.
- CHANGELOG: `[Unreleased]` Security entries for both #98 and #99.

Closes #98
Closes #99

## Verify identity

Container image / chart artifacts signed under:

- Issuer: `https://token.actions.githubusercontent.com`
- Identity regex: `^https://github\.com/digitalis-io/vals-operator/\.github/workflows/release\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$`

## Test plan

- [ ] Push pre-release tag `v0.0.0-signing-test` from this branch and trigger the workflow.
- [ ] Confirm `release` and `helm-oci` jobs succeed end-to-end.
- [ ] `cosign verify ghcr.io/digitalis-io/vals-operator:v0.0.0-signing-test --certificate-identity-regexp '...' --certificate-oidc-issuer https://token.actions.githubusercontent.com` exits 0.
- [ ] `cosign verify ghcr.io/digitalis-io/helm-charts/vals-operator:0.0.0-signing-test ...` exits 0.
- [ ] Both SBOM assets present on the GitHub Release; `jq '.packages|length' *.spdx.json` > 0; `jq '.components|length' *.cdx.json` > 0.
- [ ] `cosign verify-attestation --type spdxjson ghcr.io/digitalis-io/vals-operator@<DIGEST> ...` exits 0; predicateType is `https://spdx.dev/Document`.
- [ ] Negative test: removing `id-token: write` causes `cosign sign`/`cosign attest` to fail loudly.
- [ ] Delete the pre-release tag, image and Release after verification.

## Notes

- `anchore/sbom-action` and `sigstore/cosign-installer` pinned to full SHAs.
- `id-token: write` and `contents: write` added per-job (not workflow-level).
- Identity regex anchored at both ends with escaped dots and a strict `vX.Y.Z` suffix per security review.
- `:latest` is mutable — README explicitly directs users to verify by `vX.Y.Z` tag or digest.
- CycloneDX SBOM is published as a Release asset only; only SPDX is attested on-registry (matches issue #99 scope).